### PR TITLE
More scale tweaks

### DIFF
--- a/GameData/TweakScaleCompanion/Frameworks/CryoTanks/patches/020_ScaleExponents.cfg
+++ b/GameData/TweakScaleCompanion/Frameworks/CryoTanks/patches/020_ScaleExponents.cfg
@@ -33,6 +33,5 @@
 TWEAKSCALEEXPONENTS:NEEDS[CryoTanks,TweakScale]
 {
 	name = ModuleCryoTank
-	CoolingCost = 3		// TODO:Rebalance this one
 	minResToLeave = 2	// And this one.
 }

--- a/GameData/TweakScaleCompanion/Frameworks/SystemHeat/patches/020_ScaleExponents.cfg
+++ b/GameData/TweakScaleCompanion/Frameworks/SystemHeat/patches/020_ScaleExponents.cfg
@@ -39,24 +39,21 @@ TWEAKSCALEEXPONENTS:NEEDS[SystemHeat,TweakScale]
 TWEAKSCALEEXPONENTS:NEEDS[SystemHeat,TweakScale]
 {
 	name = ModuleSystemHeatAsteroidHarvester
+ 	systemPower = 3
 	// TODO: What I should do here?
 }
 
 TWEAKSCALEEXPONENTS:NEEDS[SystemHeat,TweakScale]
 {
 	name = ModuleSystemHeatConverter
+ 	systemPower = 3
 	// TODO: What I should do here?
 }
 
 TWEAKSCALEEXPONENTS:NEEDS[SystemHeat,TweakScale]
 {
 	name = ModuleSystemHeatEngine
-	// TODO: What I should do here?
-}
-
-TWEAKSCALEEXPONENTS:NEEDS[SystemHeat,TweakScale]
-{
-	name = ModuleSystemHeatConverter
+ 	systemPower = 2.5 // same power per unit thrust
 	// TODO: What I should do here?
 }
 
@@ -75,6 +72,8 @@ TWEAKSCALEEXPONENTS:NEEDS[SystemHeat,TweakScale]
 TWEAKSCALEEXPONENTS:NEEDS[SystemHeat,TweakScale]
 {
 	name = ModuleSystemHeatFissionEngine
+ 	HeatGeneration = 2.5 // same waste heat per unit thrust
+	systemPower = 2.5 // same power per unit thrust
 	// TODO: What I should do here?
 }
 
@@ -115,6 +114,7 @@ TWEAKSCALEEXPONENTS:NEEDS[SystemHeat,TweakScale]
 TWEAKSCALEEXPONENTS:NEEDS[SystemHeat,TweakScale]
 {
 	name = ModuleSystemHeatHarvester
+ 	systemPower = 3 // should scale with harvester speed
 	// TODO: What I should do here?
 }
 

--- a/GameData/TweakScaleCompanion/Frameworks/SystemHeat/patches/020_ScaleExponents.cfg
+++ b/GameData/TweakScaleCompanion/Frameworks/SystemHeat/patches/020_ScaleExponents.cfg
@@ -73,7 +73,7 @@ TWEAKSCALEEXPONENTS:NEEDS[SystemHeat,TweakScale]
 {
 	name = ModuleSystemHeatFissionEngine
  	HeatGeneration = 2.5 // same waste heat per unit thrust
-	systemPower = 2.5 // same power per unit thrust
+  	ElectricalGeneration = 2.5 // same electrical power per unit thrust
 	// TODO: What I should do here?
 }
 


### PR DESCRIPTION
While this is being reworked I figured I'd share some of my own install's custom changes to exponents in SystemHeat and CryoTanks. Namely:
- Removed the CoolingCost scaling for CryoTanks because (for the past couple years, and definitely in the newest version) this is a rate _per unit mass of fuel_ so the overall cooling cost already scales.
- Gave SystemHeat harvesters and converters waste heat proportional to TweakScale's normal scaling for processing rate (exponent 3). That is, same amount of waste heat per resource extracted/converted.
- `ModuleSystemHeatEngine` has `systemPower = 2.5` so waste heat scales with thrust (and fuel consumption etc.)
- Same for `ModuleSystemHeatFissionEngine`, though nothing seems to use `systemPower` so I applied it to `HeatGeneration` too.